### PR TITLE
fixing public path to be relative

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -11,7 +11,7 @@ module.exports = {
   output: {
     path: path.join(__dirname, 'dist/'),
     filename: 'bundle.js',
-    publicPath: '/dist/'
+    publicPath: 'dist/'
   },
   resolve: {
     extensions: ['', '.js', '.jsx']


### PR DESCRIPTION
I couldn't get this to work locally because in your webpack config, the path was a root relative path `/dist`, changed it to a relative path and it's running fine.
